### PR TITLE
Load instrumentations first

### DIFF
--- a/server/src/instrumentations.ts
+++ b/server/src/instrumentations.ts
@@ -1,0 +1,7 @@
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+import { PrismaInstrumentation } from '@prisma/instrumentation'
+
+export const instrumentations = [
+  getNodeAutoInstrumentations(),
+  new PrismaInstrumentation(),
+]

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -1,16 +1,15 @@
+import { instrumentations } from './instrumentations' // must be imported first
+
 import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base'
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks'
 import * as api from '@opentelemetry/api'
-import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { Resource } from '@opentelemetry/resources'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
-
 
 const contextManager = new AsyncHooksContextManager().enable()
 
@@ -37,10 +36,7 @@ provider.register();
 // Register your auto-instrumentors
 registerInstrumentations({
   tracerProvider: provider,
-  instrumentations: [
-    getNodeAutoInstrumentations(),
-    new PrismaInstrumentation(),
-  ],
+  instrumentations,
 })
 
 export const tracer = api.trace.getTracer('expenses-api');


### PR DESCRIPTION
I [enabled debug logging](https://www.aspecto.io/blog/checklist-for-troubleshooting-opentelemetry-nodejs-tracing-issues/#enable-logging) and found an issue. 

```
@opentelemetry/instrumentation-grpc Module @grpc/grpc-js has been loaded before @opentelemetry/instrumentation-grpc so it might not work, please initializ
e it before requiring @grpc/grpc-js
```

The `@opentelemetry/exporter-trace-otlp-grpc` imports `@grpc/grpc-js`, so loading that before calling `getNodeAutoInstrumentations` means that gRPC clients don't get patched with instrumentation.

I can now see gRPC traces in Jaeger from the exporter (`grpc.opentelemetry.proto.collector.trace.v1.TraceService/Export`).

I don't, however get gRPC traces from our SDK. It looks like the instrumentation hooks into `@grpc/grpc-js` at a higher level than we are using the library - [it wraps the methods on a generated client class](https://github.com/open-telemetry/opentelemetry-js/blob/93222fc65a755173d36e184af96a1863b0f64ec6/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts#L51-L64), whereas we are [using the base client class directly](https://github.com/cerbos/cerbos-sdk-javascript/blob/0c52a1676982f0b28f79f864fedaedb3cf154220/packages/grpc/src/index.ts#L99-L137) because we have our own abstraction that invokes the RPCs.